### PR TITLE
adding logging with --verbose flag

### DIFF
--- a/hserv.cabal
+++ b/hserv.cabal
@@ -58,7 +58,7 @@ executable hserv
   
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <=5, wai-app-static >=2.0,
-                       warp >=2.0, cmdargs >=0.10
+                       warp >=2.0, cmdargs >=0.10, wai-extra >=2.0
   
   -- Directories containing source files.
   hs-source-dirs:      src


### PR DESCRIPTION
Hi!

I started using `hserv` because `python -m SimpleHttpServer` was too slow.
But I found a little annoyance: the python one logs each request to stdout, which really helps in development mode.
That's why I added it, it's optional and defaults to False so it shouldn't break anything.

Let me know if there is a style rule I broke or something you don't like.

Thanks!
