### PR TITLE
adding trailing slash to directories

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,7 +6,7 @@
 module Main where
 
 import           Network.Wai.Application.Static       (defaultFileServerSettings,
-                                                       staticApp)
+                                                       staticApp, ssAddTrailingSlash)
 import           Network.Wai.Handler.Warp             (run)
 import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
 import           System.Console.CmdArgs               (Data, Typeable, cmdArgs, help,
@@ -28,4 +28,6 @@ main = do
   let middleware = if v then logStdoutDev else id
   putStrLn $ "Running hserv on port " ++ (show p)
   putStrLn $ "Go to http://0.0.0.0:" ++ (show p)
-  run p $ middleware $ staticApp $ defaultFileServerSettings "."
+  run p $ middleware $ staticApp 
+        $ (defaultFileServerSettings ".") {ssAddTrailingSlash = True}
+

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,6 +9,8 @@ import           Network.Wai.Application.Static       (defaultFileServerSettings
                                                        staticApp, ssAddTrailingSlash)
 import           Network.Wai.Handler.Warp             (run)
 import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
+import           Paths_hserv                          (version)
+import           Data.Version                         (showVersion)
 import           System.Console.CmdArgs               (Data, Typeable, cmdArgs, help,
                                                        opt, summary, (&=))
 
@@ -23,7 +25,7 @@ main = do
   hserv <- cmdArgs $ Hserv
            { port = 8888 &= help "Port on which server should run" &= opt (8888::Int)
            , verbose = False &= help "Log each request" }
-           &= summary "hserv 0.1"
+           &= summary ("hserv " ++ showVersion version)
   let Hserv {port=p, verbose=v} = hserv
   let middleware = if v then logStdoutDev else id
   putStrLn $ "Running hserv on port " ++ (show p)


### PR DESCRIPTION
There is a problem with relative links inside html documents. For example:

``` bash
mkdir test123
cd test123
echo '<html> <a href="./about.html">./about.html</a> <br> <br> 
<a href="about.html">about.html</a> </html>'  > index.html
echo '<html> <h2>About</h2> </html>' > about.html
cd ..
hserv
```

If you open in browser `http://127.0.0.1:8888`, click on `test123` you will get `File not found`, when you  try to click on links. Adding a slash to the name of the directory solves this problem.
